### PR TITLE
feat: add hex color validation

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -61,7 +61,8 @@ class Image
     
     public function accentColor(string $hexCode): self
     {
-        // TODO: Make sure it's a valid hex code
+        $this->isValidHexColor($hexCode);
+
         $this->accentColor = $hexCode;
         return $this;
     }
@@ -93,7 +94,8 @@ class Image
 
     public function backgroundColor(string $backgroundColor): self
     {
-        // TODO: Make sure it's a valid hex code
+        $this->isValidHexColor($hexCode);
+        
         $this->backgroundColor = $backgroundColor;
         return $this;
     }
@@ -114,5 +116,12 @@ class Image
             ->save($path);
 
         return $this;
+    }
+
+    function isValidHexColor($hexCode): void
+    {
+        if(!preg_match('/^#[a-f0-9]{6}$/i', $hexCode)) {
+            throw new \InvalidArgumentException('Hex code is not valid');
+        }
     }
 }

--- a/tests/hexcode_validation_test.php
+++ b/tests/hexcode_validation_test.php
@@ -1,0 +1,23 @@
+<?php
+
+use SimonHamp\TheOg\Image;
+use SimonHamp\TheOg\Background;
+
+include_once __DIR__.'/../vendor/autoload.php';
+
+try {
+    (new Image())
+    ->accentColor('#invalid')
+    ->border()
+    ->url('https://example.com/blog/some-blog-post-url')
+    ->title('Some blog post title that is quite big and quite long')
+    ->description('Some slightly smaller but potentially much longer subtext. It could be really long so we might need to trim it completely after many words')
+    ->background(Background::JustWaves, 0.2)
+    ->save(__DIR__.'/test.png');
+} catch (Exception $e) {
+    if ($e->getMessage() === 'Hex code is not valid') {
+        echo 'Hex code validation works';
+        exit(0);
+    }
+}
+


### PR DESCRIPTION
Noticed the `// TODO` comments so figured I'd implement it.

- Added a new func `isValidHexColor` to validate hex codes.
- Updated the `accentColor` and `backgroundColor` to use the new validation.
- Created a new test file `hexcode_validation_test.php` to test the hex code validation.