### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text-auto
+
+# Ignore all test and documentation with "export-ignore".
+/.gitattributes             export-ignore
+/.github                    export-ignore
+/.gitignore                 export-ignore
+/tests                      export-ignore
+


### PR DESCRIPTION
This makes sure the files indicated with `export-ignore` will _not_ be downloaded by Composer when people install this package with `composer require`. 