### PR TITLE
Fix image embed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ use SimonHamp\TheOg\Background;
 
 And here's the image that generates:
 
-![](https://github.com/simonhamp/the-og/blob/main/tests/test.png)
+![](https://github.com/simonhamp/the-og/assets/11269635/28055b75-7d8d-4c0e-b0c8-06415565c299)
 
 ### Themes
 


### PR DESCRIPTION
I've uploaded the `test1.png` from this repository's `tests` folder to GitHub's CDN (by just dragging it into an issue comment box and copying the resulting URL). 

Fixes #8.