### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,19 +7,14 @@ on:
 
 jobs:
   run-tests:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
         php: [8.2, 8.3]
         stability: [prefer-lowest, prefer-stable]
-        exclude:
-          # imagick cannot be installed for PHP 8.3 on Windows (yet)
-          - os: windows-latest
-            php: 8.3
 
-    name: PHP ${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}
+    name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,6 +14,10 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         php: [8.2, 8.3]
         stability: [prefer-lowest, prefer-stable]
+        exclude:
+          # imagick cannot be installed for PHP 8.3 on Windows (yet)
+          - os: windows-latest
+            php: 8.3
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     ],
     "require-dev": {
-        "spatie/phpunit-snapshot-assertions": "^5.1",
+        "spatie/phpunit-snapshot-assertions": "^5.1.1",
         "phpunit/phpunit": "^10.5",
         "spatie/pixelmatch-php": "^1.0"
     }

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -20,7 +20,12 @@ class IntegrationTestCase extends TestCase
             RecursiveIteratorIterator::CHILD_FIRST,
         );
 
+        /** @var \SplFileInfo $file */
         foreach ($files as $file) {
+            if ($file->getFilename() === '.gitkeep') {
+                continue;
+            }
+
             unlink($file->getRealPath());
         }
     }


### PR DESCRIPTION
This PR is a follow-up to #5. It:

- [x] Adds a `.gitkeep` file (and thereby the `tests/resources/testcases` directory) to make sure the directory exists for the tests.
- [x] Updates `spatie/phpunit-snapshot-assertions` to _at least_ v5.1.1, which fixed a bug with PNG checking.
- [x] Stops testing on Windows. `imagick` couldn't be installed on Windows on both PHP 8.2 and 8.3.