### PR TITLE
feat(Image): add toString method

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -177,4 +177,11 @@ class Image
 
         return $this;
     }
+
+    public function toString(string $format = PngEncoder::class): string
+    {
+        return $this->render()
+            ->encode(new $format)
+            ->toString();
+    }
 }


### PR DESCRIPTION
This commit adds a new `toString` method to the `Image` class.

The method allows converting the image object to a string instead of saving it to disk.


An example use case for this would be directly sending a generated image directly to an S3 bucket instead of saving it to disk first, and then sending it to S3 that way.