### PR TITLE
Ignore more meta files with .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,7 @@
 /.gitattributes             export-ignore
 /.github                    export-ignore
 /.gitignore                 export-ignore
+/phpunit.xml.dist           export-ignore
 /tests                      export-ignore
-
+/thumbnail.php              export-ignore
+/thumbnail.png              export-ignore


### PR DESCRIPTION
This PR ignores a further few "meta" files that don't need to be present in distributions of the package with `.gitattributes`.