### PR TITLE
Remove user-specific values from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
-.DS_Store
 /vendor
 /composer.lock
 /node_modules
 /phpunit.xml
 /.phpunit.cache
 
-.idea/


### PR DESCRIPTION
This PR removes user-specific values from the `.gitignore` file. They should be configured per-machine in a global `~/.gitignore` file. This ensures the project's `.gitignore` file only deals with files relevant to the project.

As [Sebastian puts it](https://sebastiandedeyne.com/setting-up-a-global-gitignore-file/):

> My repository doesn't care about your editor configuration.


