### PR TITLE
Update install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Thank you 🙏
 Install via Composer:
 
 ```shell
-composer require simonhamp/the-og --with-all-dependencies
+composer require simonhamp/the-og
 ```
 
 ## Usage


### PR DESCRIPTION
This PR removes the `--with-all-dependencies` from the installation command in the README. This option [doesn't seem to exist on the `composer require` command](https://getcomposer.org/doc/03-cli.md#require-r). Any transient dependencies will be updated automatically. Root dependencies can be updated with `--update-with-all-dependencies`, but should we really mention that in this (or every) project's README?