### PR TITLE
Fix errors occurred with Intervention Image 3.3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": "^8.2",
         "ext-imagick": "*",
-        "intervention/image": "~3.1.0"
+        "intervention/image": "~3.1"
     },
     "license": "MIT",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": "^8.2",
         "ext-imagick": "*",
-        "intervention/image": "~3.3"
+        "intervention/image": "~3.3.1"
     },
     "license": "MIT",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": "^8.2",
         "ext-imagick": "*",
-        "intervention/image": "~3.3.1"
+        "intervention/image": "^3.3"
     },
     "license": "MIT",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": "^8.2",
         "ext-imagick": "*",
-        "intervention/image": "^3.3"
+        "intervention/image": "^3.3.1"
     },
     "license": "MIT",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": "^8.2",
         "ext-imagick": "*",
-        "intervention/image": "~3.1"
+        "intervention/image": "~3.3"
     },
     "license": "MIT",
     "autoload": {

--- a/src/Layout/TextBox.php
+++ b/src/Layout/TextBox.php
@@ -80,7 +80,7 @@ class TextBox extends Box
 
     protected function generateModifier(string $text, Point $position = new Point()): CustomTextModifier
     {
-        return new CustomTextModifier(
+        return CustomTextModifier::buildSpecialized(
             new TextModifier(
                 $text,
                 $position,


### PR DESCRIPTION
In the course of the update of the Intervention Image, there was a change which means that it is no longer possible to instantiate so-called "driver-specific" modifiers yourself. After the update the initialization is always done by a generic class via the respective driver class. This fix sets the initialization of the "driver specific class" to the static helper method used by the driver of the dependency itself.

See https://github.com/Intervention/image/issues/1281