### PR TITLE
Fix TextBox line height type

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3]
+        php: [8.2, 8.3, 8.4]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}

--- a/src/Layout/TextBox.php
+++ b/src/Layout/TextBox.php
@@ -20,7 +20,7 @@ class TextBox extends Box
     public ColorInterface $color;
     public Font $font;
     public string $hAlign;
-    public int $lineHeight;
+    public float $lineHeight;
     public int $size;
     public string $text;
     public string $vAlign;
@@ -43,7 +43,7 @@ class TextBox extends Box
         return $this;
     }
 
-    public function lineHeight(int $lineHeight): self
+    public function lineHeight(float $lineHeight): self
     {
         $this->lineHeight = $lineHeight;
         return $this;


### PR DESCRIPTION
`\Intervention\Image\Typography\FontFactory` lets you call `lineHeight` with a float for more line height flexibility. Currently, the package only lets you provide a custom line height as an int. Since the default value is 1.6, this seems like an oversight.

This fix lets you set it to e.g. `1.8`, which may be better if you are using a custom font or want to have more granular control over the layout that is being rendered, which is my own use case.

(Unsure why one of the tests fails, by the way. Runs fine locally, but guessing it's because you're doing some HTTP requests that may not work correctly on one of the runners here?)