### PR TITLE
Migrate to Intervention Image v4

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3, 8.4]
+        php: [8.3, 8.4]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}

--- a/README.md
+++ b/README.md
@@ -374,7 +374,8 @@ use Intervention\Image\Interfaces\ImageInterface;
 
 public function render(ImageInterface $image)
 {
-  $image->drawCircle(10, 10, function ($circle) {
+  $image->drawCircle(function ($circle) {
+      $circle->at(10, 10);
       $circle->radius(150);
       $circle->background('lightblue');
       $circle->border('b53717', 1);

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "license": "MIT",
     "type": "library",
     "require": {
-        "php": "^8.2",
-        "intervention/image": "^3.4.0"
+        "php": "^8.3",
+        "intervention/image": "^4.0"
     },
     "require-dev": {
         "spatie/phpunit-snapshot-assertions": "^5.1.1",

--- a/src/Border.php
+++ b/src/Border.php
@@ -2,7 +2,7 @@
 
 namespace SimonHamp\TheOg;
 
-use Intervention\Image\Colors\Rgb\Color;
+use Intervention\Image\Color;
 use Intervention\Image\Interfaces\ColorInterface;
 
 class Border
@@ -11,7 +11,7 @@ class Border
     protected int $width;
     protected string $color;
 
-    public function color(ColorInterface $color): self
+    public function color(string $color): self
     {
         $this->color = $color;
         return $this;
@@ -19,7 +19,7 @@ class Border
 
     public function getColor(): ColorInterface
     {
-        return Color::create($this->color);
+        return Color::parse($this->color);
     }
 
     public function position(BorderPosition $position): self

--- a/src/Image.php
+++ b/src/Image.php
@@ -2,7 +2,6 @@
 
 namespace SimonHamp\TheOg;
 
-use Intervention\Image\Colors\Rgb\Color;
 use Intervention\Image\Encoders\PngEncoder;
 use Intervention\Image\Image as RenderedImage;
 use Intervention\Image\Interfaces\EncoderInterface;
@@ -31,7 +30,7 @@ class Image
 
     public function __construct()
     {
-        $this->layout(new Standard);
+        $this->layout(new Standard());
         $this->theme(BuiltInTheme::Light);
     }
 
@@ -161,12 +160,12 @@ class Image
     /**
      * Override the layout's default border
      */
-    public function border(?BorderPosition $position = null, ?Color $color = null, ?int $width = null): self
+    public function border(?BorderPosition $position = null, ?string $color = null, ?int $width = null): self
     {
         $this->layout->border(
             (new Border())
                 ->position($position ?? $this->layout->getBorderPosition())
-                ->color($color ?? $this->theme->getBorderColor())
+                ->color($color ?? $this->theme->getBorderColor()->toString())
                 ->width($width ?? $this->layout->getBorderWidth())
         );
 
@@ -205,7 +204,7 @@ class Image
         return $this;
     }
 
-    public function toString(EncoderInterface $encoder = new PngEncoder): string
+    public function toString(EncoderInterface $encoder = new PngEncoder()): string
     {
         return $this->render()
             ->encode($encoder)

--- a/src/Interfaces/Box.php
+++ b/src/Interfaces/Box.php
@@ -2,8 +2,8 @@
 
 namespace SimonHamp\TheOg\Interfaces;
 
-use Intervention\Image\Geometry\Point;
 use Intervention\Image\Interfaces\ImageInterface;
+use Intervention\Image\Interfaces\PointInterface;
 use Intervention\Image\Interfaces\SizeInterface;
 use SimonHamp\TheOg\Layout\Position;
 
@@ -11,7 +11,7 @@ interface Box
 {
     public function setCanvas(ImageInterface $canvas): static;
 
-    public function anchor(?Position $position = null): Point;
+    public function anchor(?Position $position = null): PointInterface;
 
     public function name(string $name): static;
 

--- a/src/Interfaces/Layout.php
+++ b/src/Interfaces/Layout.php
@@ -2,10 +2,9 @@
 
 namespace SimonHamp\TheOg\Interfaces;
 
-use Intervention\Image\Image;
+use Intervention\Image\Interfaces\ImageInterface;
 use SimonHamp\TheOg\Border;
 use SimonHamp\TheOg\Image as Config;
-use SimonHamp\TheOg\Layout\TextBox;
 use SimonHamp\TheOg\Theme\Picture;
 
 interface Layout
@@ -20,7 +19,7 @@ interface Layout
 
     public function picture(): ?Picture;
 
-    public function render(Config $config): Image;
+    public function render(Config $config): ImageInterface;
 
     public function title(): string;
 

--- a/src/Layout/Box.php
+++ b/src/Layout/Box.php
@@ -152,12 +152,9 @@ class Box implements BoxInterface
         $this->box->setBackgroundColor('orange');
         $this->box->setBorder('red');
         $this->box->setPivot($position);
+        $this->box->setPosition($position);
 
-        $this->canvas()->drawRectangle(
-            $position->x(),
-            $position->y(),
-            $this->box,
-        );
+        $this->canvas()->drawRectangle($this->box);
     }
 
     public function name(string $name): static

--- a/src/Layout/Concerns/HasText.php
+++ b/src/Layout/Concerns/HasText.php
@@ -52,20 +52,20 @@ trait HasText
 
     protected function interventionFontInstance(): FontInterface
     {
-        return (new FontFactory(function (FontFactory $factory) {
+        return FontFactory::build(function (FontFactory $factory) {
             $factory->filename($this->font->path());
             $factory->size($this->size);
             $factory->color($this->color);
 
             if (isset($this->hAlign)) {
-                $factory->align($this->hAlign);
+                $factory->align(horizontal: $this->hAlign);
             }
 
-            $factory->valign($this->vAlign ?? 'top');
+            $factory->align(vertical: $this->vAlign ?? 'top');
 
             $factory->lineHeight($this->lineHeight ?? 1.6);
 
             $factory->wrap($this->box->width());
-        }))();
+        });
     }
 }

--- a/src/Layout/PictureBox.php
+++ b/src/Layout/PictureBox.php
@@ -5,6 +5,7 @@ namespace SimonHamp\TheOg\Layout;
 use Imagick;
 use ImagickDraw;
 use ImagickPixel;
+use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
 use Intervention\Image\ImageManager;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\SizeInterface;
@@ -33,10 +34,10 @@ class PictureBox extends Box
 
         $position = $this->calculatePosition();
 
-        $this->canvas()->place(
-            element: $this->getPicture(),
-            offset_x: $position->x(),
-            offset_y: $position->y()
+        $this->canvas()->insert(
+            image: $this->getPicture(),
+            x: $position->x(),
+            y: $position->y()
         );
     }
 
@@ -93,8 +94,8 @@ class PictureBox extends Box
 
     protected function getPicture(): ImageInterface
     {
-        $this->picture ??= ImageManager::imagick()
-            ->read(file_get_contents($this->path));
+        $this->picture ??= ImageManager::usingDriver(ImagickDriver::class)
+            ->decodeBinary(file_get_contents($this->path));
 
         match ($this->placement) {
             PicturePlacement::Cover => $this->picture->cover($this->box->width(), $this->box->height()),

--- a/src/Layout/TextBox.php
+++ b/src/Layout/TextBox.php
@@ -3,10 +3,9 @@
 namespace SimonHamp\TheOg\Layout;
 
 use Intervention\Image\Geometry\Point;
-use Intervention\Image\Geometry\Rectangle;
-use Intervention\Image\Interfaces\ModifierInterface;
 use Intervention\Image\Interfaces\SizeInterface;
 use Intervention\Image\Modifiers\TextModifier;
+use Intervention\Image\Size;
 use Intervention\Image\Typography\Line;
 use Intervention\Image\Typography\TextBlock;
 use SimonHamp\TheOg\Layout\Concerns\HasAlignment;
@@ -17,7 +16,7 @@ class TextBox extends Box
     use HasText;
     use HasAlignment;
 
-    protected ?ModifierInterface $modifier = null;
+    protected ?TextModifier $modifier = null;
 
     public function render(): void
     {
@@ -36,13 +35,13 @@ class TextBox extends Box
         $wrappedTextBlock = $this->wrappedTextBlockForModifier($modifier);
 
         // Create a bounding box, see: https://github.com/Intervention/image/blob/develop/src/Drivers/AbstractFontProcessor.php#L166
-        return new Rectangle(
+        return new Size(
             $driver->fontProcessor()->boxSize((string) $wrappedTextBlock->longestLine(), $modifier->font)->width(),
             $driver->fontProcessor()->leading($modifier->font) * ($wrappedTextBlock->count() - 1) + $driver->fontProcessor()->capHeight($modifier->font)
         );
     }
 
-    public function modifier(string $text): ModifierInterface
+    public function modifier(string $text): TextModifier
     {
         if (! is_null($this->modifier)) {
             return $this->modifier;
@@ -57,7 +56,7 @@ class TextBox extends Box
         return $this->modifier;
     }
 
-    protected function truncateText(ModifierInterface $modifier): ModifierInterface
+    protected function truncateText(TextModifier $modifier): TextModifier
     {
         $expectedHeight = $this->dimensions()->height();
 
@@ -72,7 +71,7 @@ class TextBox extends Box
 
         $truncatedLines = [
             ...array_slice($wrappedTextBlock->toArray(), 0, $maxLines - 1),
-            $this->applyEllipsis($wrappedTextBlock->getAtPosition($maxLines - 1)),
+            $this->applyEllipsis($wrappedTextBlock->at($maxLines - 1)),
         ];
 
         $modifier->text = implode("\n", $truncatedLines);
@@ -88,7 +87,7 @@ class TextBox extends Box
         );
     }
 
-    protected function wrappedTextBlockForModifier(ModifierInterface $modifier): TextBlock
+    protected function wrappedTextBlockForModifier(TextModifier $modifier): TextBlock
     {
         $driver = $this->canvas()->driver();
 

--- a/src/Theme/Theme.php
+++ b/src/Theme/Theme.php
@@ -2,7 +2,7 @@
 
 namespace SimonHamp\TheOg\Theme;
 
-use Intervention\Image\Colors\Rgb\Color;
+use Intervention\Image\Color;
 use Intervention\Image\Interfaces\ColorInterface;
 use SimonHamp\TheOg\Interfaces\Background;
 use SimonHamp\TheOg\Interfaces\Font;
@@ -38,7 +38,7 @@ class Theme implements ThemeInterface
 
     public function getAccentColor(): ColorInterface
     {
-        return Color::create($this->accentColor);
+        return Color::parse($this->accentColor);
     }
 
     public function background(Background $background): self
@@ -60,7 +60,7 @@ class Theme implements ThemeInterface
 
     public function getBackgroundColor(): ColorInterface
     {
-        return Color::create($this->backgroundColor);
+        return Color::parse($this->backgroundColor);
     }
 
     public function baseColor(string $color): self
@@ -71,7 +71,7 @@ class Theme implements ThemeInterface
 
     public function getBaseColor(): ColorInterface
     {
-        return Color::create($this->baseColor);
+        return Color::parse($this->baseColor);
     }
 
     public function baseFont(Font $font): self
@@ -94,7 +94,7 @@ class Theme implements ThemeInterface
 
     public function getBorderColor(): ColorInterface
     {
-        return Color::create($this->borderColor ?? $this->accentColor);
+        return Color::parse($this->borderColor ?? $this->accentColor);
     }
 
     public function callToActionBackgroundColor(string $color): self
@@ -105,7 +105,7 @@ class Theme implements ThemeInterface
 
     public function getCallToActionBackgroundColor(): ColorInterface
     {
-        return Color::create($this->callToActionBackgroundColor ?? $this->accentColor);
+        return Color::parse($this->callToActionBackgroundColor ?? $this->accentColor);
     }
 
     public function callToActionColor(string $color): self
@@ -116,7 +116,7 @@ class Theme implements ThemeInterface
 
     public function getCallToActionColor(): ColorInterface
     {
-        return Color::create($this->callToActionColor ?? $this->baseColor);
+        return Color::parse($this->callToActionColor ?? $this->baseColor);
     }
 
     public function callToActionFont(Font $font): self
@@ -138,7 +138,7 @@ class Theme implements ThemeInterface
 
     public function getDescriptionColor(): ColorInterface
     {
-        return Color::create($this->descriptionColor ?? $this->baseColor);
+        return Color::parse($this->descriptionColor ?? $this->baseColor);
     }
 
     public function descriptionFont(Font $font): self
@@ -160,7 +160,7 @@ class Theme implements ThemeInterface
 
     public function getTitleColor(): ColorInterface
     {
-        return Color::create($this->titleColor ?? $this->baseColor);
+        return Color::parse($this->titleColor ?? $this->baseColor);
     }
 
     public function titleFont(Font $font): self
@@ -182,7 +182,7 @@ class Theme implements ThemeInterface
 
     public function getUrlColor(): ColorInterface
     {
-        return Color::create($this->urlColor ?? $this->accentColor);
+        return Color::parse($this->urlColor ?? $this->accentColor);
     }
 
     public function urlFont(Font $font): self

--- a/src/Traits/RendersFeatures.php
+++ b/src/Traits/RendersFeatures.php
@@ -3,8 +3,12 @@
 namespace SimonHamp\TheOg\Traits;
 
 use Imagick;
-use Intervention\Image\Image;
+use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
+use Intervention\Image\Geometry\Factories\RectangleFactory;
+use Intervention\Image\Geometry\Rectangle;
 use Intervention\Image\ImageManager;
+use Intervention\Image\Interfaces\ImageInterface;
+use Intervention\Image\Interfaces\ImageManagerInterface;
 use InvalidArgumentException;
 use SimonHamp\TheOg\Border;
 use SimonHamp\TheOg\BorderPosition;
@@ -15,16 +19,16 @@ use SimonHamp\TheOg\Theme\BackgroundPlacement;
 trait RendersFeatures
 {
     protected Config $config;
-    protected Image $canvas;
-    protected ImageManager $manager;
+    protected ImageInterface $canvas;
+    protected ImageManagerInterface $manager;
 
-    public function render(Config $config): Image
+    public function render(Config $config): ImageInterface
     {
         $this->config = $config;
 
-        $this->manager = ImageManager::imagick();
+        $this->manager = ImageManager::usingDriver(ImagickDriver::class);
 
-        $this->canvas = $this->manager->create($this->width, $this->height)
+        $this->canvas = $this->manager->createImage($this->width, $this->height)
             ->fill($this->config->theme->getBackgroundColor());
 
         if ($this->config->theme->getBackground() instanceof Background) {
@@ -71,46 +75,54 @@ trait RendersFeatures
 
     protected function renderBorderLeft(): void
     {
-        $this->canvas->drawRectangle(0, 0, $this->renderVerticalAccentedRectangle());
+        $this->canvas->drawRectangle(
+            $this->verticalAccentedRectangle()->adjust(
+                fn(RectangleFactory $rectangle) => $rectangle->at(0, 0)
+            )
+        );
     }
 
     protected function renderBorderRight(): void
     {
         $this->canvas->drawRectangle(
-            $this->width - $this->border->getWidth(),
-            0,
-            $this->renderVerticalAccentedRectangle()
+            $this->verticalAccentedRectangle()->adjust(
+                fn(RectangleFactory $rectangle) => $rectangle->at($this->width - $this->border->getWidth(), 0)
+            )
         );
     }
 
     protected function renderBorderTop(): void
     {
-        $this->canvas->drawRectangle(0, 0, $this->renderHorizontalAccentedRectangle());
+        $this->canvas->drawRectangle(
+            $this->horizontalAccentedRectangle()->adjust(
+                fn(RectangleFactory $rectangle) => $rectangle->at(0, 0)
+            )
+        );
     }
 
     protected function renderBorderBottom(): void
     {
         $this->canvas->drawRectangle(
-            0,
-            $this->height - $this->border->getWidth(),
-            $this->renderHorizontalAccentedRectangle()
+            $this->horizontalAccentedRectangle()->adjust(
+                fn(RectangleFactory $rectangle) => $rectangle->at(0, $this->height - $this->border->getWidth())
+            )
         );
     }
 
-    protected function renderVerticalAccentedRectangle(): callable
+    protected function verticalAccentedRectangle(): Rectangle
     {
-        return function ($rectangle) {
+        return RectangleFactory::build(function ($rectangle) {
             $rectangle->size($this->border->getWidth(), $this->height);
             $rectangle->background($this->border->getColor());
-        };
+        });
     }
 
-    protected function renderHorizontalAccentedRectangle(): callable
+    protected function horizontalAccentedRectangle(): Rectangle
     {
-        return function ($rectangle) {
+        return RectangleFactory::build(function ($rectangle) {
             $rectangle->size($this->width, $this->border->getWidth());
             $rectangle->background($this->border->getColor());
-        };
+        });
     }
 
     /**
@@ -132,7 +144,7 @@ trait RendersFeatures
             $data = file_get_contents($path);
         }
 
-        $panel = $this->manager->read($data ?? $path);
+        $panel = $this->manager->decode($data ?? $path);
 
         $imagick = $panel->core()->native();
 
@@ -152,7 +164,7 @@ trait RendersFeatures
         };
     }
 
-    protected function renderBackgroundRepeat(Image $panel): void
+    protected function renderBackgroundRepeat(ImageInterface $panel): void
     {
         $width = $panel->width();
         $height = $panel->height();
@@ -166,10 +178,10 @@ trait RendersFeatures
             $filledColumns = 0;
 
             while ($filledColumns <= $columns) {
-                $this->canvas->place(
-                    element: $panel,
-                    offset_x: $filledColumns * $width,
-                    offset_y: $filledRows * $height,
+                $this->canvas->insert(
+                    image: $panel,
+                    x: $filledColumns * $width,
+                    y: $filledRows * $height,
                 );
 
                 ++$filledColumns;
@@ -182,10 +194,10 @@ trait RendersFeatures
     /**
      * Resizes the background image to cover the canvas.
      *
-     * @param Image $panel
+     * @param ImageInterface $panel
      */
-    protected function renderBackgroundCover(Image $panel): void
+    protected function renderBackgroundCover(ImageInterface $panel): void
     {
-        $this->canvas->place($panel->cover($this->width, $this->height));
+        $this->canvas->insert($panel->cover($this->width, $this->height));
     }
 }


### PR DESCRIPTION
This PR makes the necessary changes to migrate to the just released [Intervention Image Version 4](https://github.com/Intervention/image/releases/tag/4.0.0).

Please note that the new version requires at least PHP 8.3.

As part of this, I fixed an issue: The README states that “Throughout The OG, colors can be expressed as hex codes, rgba, or HTML-named colors”. I noticed that `SimonHamp\TheOg\Image::border()` only accepted ColorInterface. I changed that to `string`.

All in all, I think this is a good start and the PR takes care of most of the work for the update. I recommend a thorough review.

If you have any questions, feel free to reach out to me.

PS: For your reference, here is the [upgrade guide](https://image.intervention.io/v4/getting-started/upgrade)